### PR TITLE
fix: timer ticks twice

### DIFF
--- a/src/Timer.js
+++ b/src/Timer.js
@@ -24,6 +24,7 @@ class Timer extends EventEmitter {
 
     if (this.immediate) {
       this.tick();
+      this.isRunning = true; // prevent timer tick twice, fixed issues #4
     }
 
     this.start();


### PR DESCRIPTION
When used the `options.immediate` ，the `tick()` was called, the inside timer is running, so prevented the `start()` setup a other timer. fixed #4 